### PR TITLE
 Bugfix for invalid trailing unused trits

### DIFF
--- a/src/main/java/com/aidos/ari/model/Transaction.java
+++ b/src/main/java/com/aidos/ari/model/Transaction.java
@@ -118,7 +118,8 @@ public class Transaction {
         curl.squeeze(hashTrits, 0, hashTrits.length);
 
         hash = Converter.bytes(hashTrits);
-        if (hash[Hash.SIZE_IN_BYTES - 4] != 0 || hash[Hash.SIZE_IN_BYTES - 3] != 0 || hash[Hash.SIZE_IN_BYTES - 2] != 0 || hash[Hash.SIZE_IN_BYTES - 1] != 0) {
+         if (hash[Hash.SIZE_IN_BYTES - 4] != 0) { // trits 14-18 must be 0,  trits 0-12 further checked by minWeightMagnitude
+                                                  // bugfix removed Hash 0-3 as there are dangling unused trits which can be non-0
             throw new RuntimeException("Invalid transaction hash");
         }
 


### PR DESCRIPTION
 Bugfix for invalid trailing unused trits. Prevents node syncing as some valid old transactions have non 0 values in the last 3 trailing trits (due to the length discrepancy between 43 bytes and 243 trits. bugfix.