### PR TITLE
Major Speedup and Added Local Snapshots

### DIFF
--- a/src/main/java/com/aidos/ari/Main.java
+++ b/src/main/java/com/aidos/ari/Main.java
@@ -20,7 +20,7 @@ public class Main {
 	private static final Logger log = LoggerFactory.getLogger(Main.class);
 
 	public static final String NAME = "ARI";
-	public static final String VERSION = "1.0.2.0";
+	public static final String VERSION = "1.0.3.0";
 
 	public static void main(final String[] args) {
 

--- a/src/main/java/com/aidos/ari/Milestone.java
+++ b/src/main/java/com/aidos/ari/Milestone.java
@@ -1,7 +1,9 @@
 package com.aidos.ari;
 
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -42,9 +44,57 @@ public class Milestone {
 	private static final Set<Long> analyzedMilestoneCandidates = new HashSet<>();
 	private static final Map<Integer, Hash> milestones = new ConcurrentHashMap<>();
 
+	private static Boolean initialScanCompleted = false; // perform an initial scan of the milestone storage to speed up node restarts
+	private static Boolean initialSnapshotCompleted = false; 
+	
+	static class MilestoneElement implements Comparable<MilestoneElement> { 
+		int msindex = 0;
+		long pointer = -1;
+		MilestoneElement(Long p_pointer) {
+			pointer = p_pointer;
+			final Transaction transaction = StorageTransactions.instance().loadTransaction(pointer);
+			msindex = (int) Converter.longValue(transaction.trits(), Transaction.TAG_TRINARY_OFFSET,15);
+			if (msindex > 1048576 || msindex < 0)
+				msindex = -1;
+	    }
+		@Override
+		public int compareTo(MilestoneElement me) {
+			return msindex-me.msindex;
+		}
+	}
+	
 	public static void updateLatestMilestone() {
-
-		for (final Long pointer : StorageAddresses.instance().addressesOf(COORDINATOR)) {
+		
+		List<Long> cooTransPointers = StorageAddresses.instance().addressesOf(COORDINATOR); // load all transactions with address==coo
+		
+		synchronized(initialScanCompleted) { // for the initial load we will rearrange this list so high ms candidates come first
+			if (!initialScanCompleted) {
+				log.info("performing initial milestone scan sort on {} transactions",cooTransPointers.size());
+				List<MilestoneElement> meList= new ArrayList<MilestoneElement>();
+				int percCompleted = 0, lastPercCompleted = -1, counter = 0;
+				for (final Long pointer : cooTransPointers) {
+					percCompleted = (int)((counter++)*100.0/cooTransPointers.size());
+					if (percCompleted>lastPercCompleted) {
+						lastPercCompleted = percCompleted;
+						log.info("initial storage milestone load {}% complete",percCompleted);
+					}
+					MilestoneElement me = new MilestoneElement(pointer);
+					if (me.msindex>=0)
+						meList.add(new MilestoneElement(pointer));
+				}	
+				Collections.sort(meList); // sort by Milestone Index
+				Collections.reverse(meList); // and reverse (latest MS first)
+				initialScanCompleted = true;
+				if (meList.size()>0) {
+					cooTransPointers.clear();
+					for (MilestoneElement me2 : meList) {
+						cooTransPointers.add(me2.pointer);
+					}
+				}
+			}
+		}
+		
+		for (final Long pointer : cooTransPointers) {
 
 			if (analyzedMilestoneCandidates.add(pointer)) {
 
@@ -122,18 +172,20 @@ public class Milestone {
 			if (milestone != null) {
 
 				boolean solid = true;
-
+				log.info("solidSubmeshMilestone: checking solidity for MS {}",milestoneIndex);
 				synchronized (StorageScratchpad.instance().getAnalyzedTransactionsFlags()) {
 
 					StorageScratchpad.instance().clearAnalyzedTransactionsFlags();
-
+					Long transactionCount = 0L;
 					final Queue<Long> nonAnalyzedTransactions = new LinkedList<>();
 					nonAnalyzedTransactions.offer(StorageTransactions.instance().transactionPointer(milestone.bytes()));
 					Long pointer;
 					while ((pointer = nonAnalyzedTransactions.poll()) != null) {
-
 						if (StorageScratchpad.instance().setAnalyzedTransactionFlag(pointer)) {
-
+							if (transactionCount%100000==0)
+								log.info("solidSubmeshMilestone: checked {} transactions",transactionCount);
+							transactionCount++;
+							
 							final Transaction transaction2 = StorageTransactions.instance().loadTransaction(pointer);
 							if (transaction2.type == AbstractStorage.PREFILLED_SLOT) {
 								solid = false;
@@ -150,6 +202,10 @@ public class Milestone {
 				if (solid) {
 					latestSolidSubmeshMilestone = milestone;
 					latestSolidSubmeshMilestoneIndex = milestoneIndex;
+					if (initialScanCompleted && !initialSnapshotCompleted) {
+						Snapshot.updateSnapshot(); // updating the first snapshot (e.g. after a restart). thereafter it has to be requested via an API call
+						initialSnapshotCompleted = true;
+					}
 					return;
 				}
 			}

--- a/src/main/java/com/aidos/ari/Milestone.java
+++ b/src/main/java/com/aidos/ari/Milestone.java
@@ -203,8 +203,8 @@ public class Milestone {
 					latestSolidSubmeshMilestone = milestone;
 					latestSolidSubmeshMilestoneIndex = milestoneIndex;
 					if (initialScanCompleted && !initialSnapshotCompleted) {
-						Snapshot.updateSnapshot(); // updating the first snapshot (e.g. after a restart). thereafter it has to be requested via an API call
 						initialSnapshotCompleted = true;
+						Snapshot.updateSnapshot(); // updating the first snapshot (e.g. after a restart). thereafter it has to be requested via an API call
 					}
 					return;
 				}

--- a/src/main/java/com/aidos/ari/service/TipsManager.java
+++ b/src/main/java/com/aidos/ari/service/TipsManager.java
@@ -65,237 +65,241 @@ public class TipsManager {
     }
 
     static synchronized Hash transactionToApprove(final Hash extraTip, int depth) {
+    	try {
+			Snapshot.updateSnapshotSemaphore.acquireUninterruptibly(); // ensure the Snapshot is not currently being calculated
 
-        final Hash preferableMilestone = Milestone.latestSolidSubmeshMilestone;
-
-        synchronized (StorageScratchpad.instance().getAnalyzedTransactionsFlags()) {
-
-        	StorageScratchpad.instance().clearAnalyzedTransactionsFlags();
-
-            Map<Hash, Long> state = new HashMap<>(Snapshot.initialState);
-
-            {
-                int numberOfAnalyzedTransactions = 0;
-
-                final Queue<Long> nonAnalyzedTransactions = new LinkedList<>(Collections.singleton(StorageTransactions.instance().transactionPointer((extraTip == null ? preferableMilestone : extraTip).bytes())));
-                Long pointer;
-                while ((pointer = nonAnalyzedTransactions.poll()) != null) {
-
-                    if (StorageScratchpad.instance().setAnalyzedTransactionFlag(pointer)) {
-
-                        numberOfAnalyzedTransactions++;
-
-                        final Transaction transaction = StorageTransactions.instance().loadTransaction(pointer);
-                        if (transaction.type == Storage.PREFILLED_SLOT) {
-                            return null;
-                        } else {
-
-                            if (transaction.currentIndex == 0) {
-
-                                boolean validBundle = false;
-
-                                final Bundle bundle = new Bundle(transaction.bundle);
-                                for (final List<Transaction> bundleTransactions : bundle.getTransactions()) {
-
-                                    if (bundleTransactions.get(0).pointer == transaction.pointer) {
-
-                                        validBundle = true;
-
-                                        bundleTransactions.stream().filter(bundleTransaction -> bundleTransaction.value != 0).forEach(bundleTransaction -> {
-
-                                        
-                                        
-                                        });
-                                        break;
-                                    }
-                                }
-
-                                if (!validBundle) {
-                                    return null;
-                                }
-                            }
-                            if (transaction.value != 0) {
-	                            final Hash address = new Hash(transaction.address);
-	                            final Long value = state.get(address);
-	                            state.put(address, value == null ? transaction.value : (value + transaction.value));
-                            }
-                            nonAnalyzedTransactions.offer(transaction.trunkTransactionPointer);
-                            nonAnalyzedTransactions.offer(transaction.branchTransactionPointer);
-                        }
-                    }
-                }
-
-                log.info("Confirmed transactions = {}", numberOfAnalyzedTransactions);
-            }
-
-            final Iterator<Map.Entry<Hash, Long>> stateIterator = state.entrySet().iterator();
-            while (stateIterator.hasNext()) {
-
-                final Map.Entry<Hash, Long> entry = stateIterator.next();
-                if (entry.getValue() <= 0) {
-
-                    if (entry.getValue() < 0) {
-                    	log.error("Ledger inconsistency detected");
-                        return null;
-                    }
-                    stateIterator.remove();
-                }
-            }
-
-            StorageScratchpad.instance().saveAnalyzedTransactionsFlags();
-            StorageScratchpad.instance().clearAnalyzedTransactionsFlags();
-
-            final Set<Hash> tailsToAnalyze = new HashSet<>();
-
-            Hash tip = preferableMilestone;
-            if (extraTip != null) {
-
-                Transaction transaction = StorageTransactions.instance().loadTransaction(StorageTransactions.instance().transactionPointer(tip.bytes()));
-                while (depth-- > 0 && !tip.equals(Hash.NULL_HASH)) {
-
-                    tip = new Hash(transaction.hash, 0, Transaction.HASH_SIZE);
-                    do {
-                        transaction = StorageTransactions.instance().loadTransaction(transaction.trunkTransactionPointer);
-                    } while (transaction.currentIndex != 0);
-                }
-            }
-            final Queue<Long> nonAnalyzedTransactions = new LinkedList<>(Collections.singleton(StorageTransactions.instance().transactionPointer(tip.bytes())));
-            Long pointer;
-            while ((pointer = nonAnalyzedTransactions.poll()) != null) {
-
-                if (StorageScratchpad.instance().setAnalyzedTransactionFlag(pointer)) {
-
-                    final Transaction transaction = StorageTransactions.instance().loadTransaction(pointer);
-
-                    if (transaction.currentIndex == 0) {
-                        tailsToAnalyze.add(new Hash(transaction.hash, 0, Transaction.HASH_SIZE));
-                    }
-
-                    StorageApprovers.instance().approveeTransactions(StorageApprovers.instance().approveePointer(transaction.hash)).forEach(nonAnalyzedTransactions::offer);
-                }
-            }
-
-            if (extraTip != null) {
-
-                StorageScratchpad.instance().loadAnalyzedTransactionsFlags();
-
-                final Iterator<Hash> tailsToAnalyzeIterator = tailsToAnalyze.iterator();
-                while (tailsToAnalyzeIterator.hasNext()) {
-
-                    final Transaction tail = StorageTransactions.instance().loadTransaction(tailsToAnalyzeIterator.next().bytes());
-                    if (StorageScratchpad.instance().analyzedTransactionFlag(tail.pointer)) {
-                        tailsToAnalyzeIterator.remove();
-                    }
-                }
-            }
-
-            log.info(tailsToAnalyze.size() + " tails need to be analyzed");
-            Hash bestTip = preferableMilestone;
-            int bestRating = 0;
-            for (final Hash tail : tailsToAnalyze) {
-
-            	StorageScratchpad.instance().loadAnalyzedTransactionsFlags();
-
-                Set<Hash> extraTransactions = new HashSet<>();
-
-                nonAnalyzedTransactions.clear();
-                nonAnalyzedTransactions.offer(StorageTransactions.instance().transactionPointer(tail.bytes()));
-                while ((pointer = nonAnalyzedTransactions.poll()) != null) {
-
-                    if (StorageScratchpad.instance().setAnalyzedTransactionFlag(pointer)) {
-
-                        final Transaction transaction = StorageTransactions.instance().loadTransaction(pointer);
-                        
-                        if (transaction.type == Storage.PREFILLED_SLOT) {
-                            extraTransactions = null;
-                            break;
-                        } else {
-                        	
-                        	int weightMagnitude = 0;
-                            int[] transactionTrits = new Hash(transaction.hash, 0, Transaction.HASH_SIZE).trits();
-                            for (int pos = transactionTrits.length-1; pos>=0; pos-- ) {
-                            	if (transactionTrits[pos] == 0) weightMagnitude++;
-                            	else break;
-                            }
-                            
-                            if (weightMagnitude < minWeightMagnitude) {
-                            	extraTransactions = null;
-                                break;
-                            }
-                        	
-                            extraTransactions.add(new Hash(transaction.hash, 0, Transaction.HASH_SIZE));
-                            nonAnalyzedTransactions.offer(transaction.trunkTransactionPointer);
-                            nonAnalyzedTransactions.offer(transaction.branchTransactionPointer);
-                        }
-                    }
-                }
-
-                if (extraTransactions != null) {
-
-                    Set<Hash> extraTransactionsCopy = new HashSet<>(extraTransactions);
-
-                    for (final Hash extraTransaction : extraTransactions) {
-
-                        final Transaction transaction = StorageTransactions.instance().loadTransaction(extraTransaction.bytes());
-                        if (transaction != null && transaction.currentIndex == 0) {
-
-                            final Bundle bundle = new Bundle(transaction.bundle);
-                            for (final List<Transaction> bundleTransactions : bundle.getTransactions()) {
-
-                                if (Arrays.equals(bundleTransactions.get(0).hash, transaction.hash)) {
-
-                                    for (final Transaction bundleTransaction : bundleTransactions) {
-
-                                        if (!extraTransactionsCopy.remove(new Hash(bundleTransaction.hash, 0, Transaction.HASH_SIZE))) {
-                                            extraTransactionsCopy = null;
-                                            break;
-                                        }
-                                    }
-                                    break;
-                                }
-                            }
-                        }
-                        if (extraTransactionsCopy == null) {
-                            break;
-                        }
-                    }
-
-                    if (extraTransactionsCopy != null && extraTransactionsCopy.isEmpty()) {
-
-                        final Map<Hash, Long> stateCopy = new HashMap<>(state);
-
-                        for (final Hash extraTransaction : extraTransactions) {
-
-                            final Transaction transaction = StorageTransactions.instance().loadTransaction(extraTransaction.bytes());
-                            if (transaction.value != 0) {
-                                final Hash address = new Hash(transaction.address);
-                                final Long value = stateCopy.get(address);
-                                stateCopy.put(address, value == null ? transaction.value : (value + transaction.value));
-                            }
-                        }
-                        long total = 0l;
-                        for (final long value : stateCopy.values()) {
-                            if (value < 0) {
-                                extraTransactions = null;
-                                break;
-                            }
-                            total += value;
-                        }
-                        if (total != 2500000000000000l) {
-                        	log.info("discarding tip. would cause invalid state.");
-                        }
-                        if (extraTransactions != null) {
-                            if (extraTransactions.size() > bestRating) {
-                                bestTip = tail;
-                                bestRating = extraTransactions.size();
-                            }
-                        }
-                    }
-                }
-            }
-            log.info("{} extra transactions approved", bestRating);
-            return bestTip;
-        }
+	        final Hash preferableMilestone = Milestone.latestSolidSubmeshMilestone;
+	
+	        synchronized (StorageScratchpad.instance().getAnalyzedTransactionsFlags()) {
+	
+	        	StorageScratchpad.instance().clearAnalyzedTransactionsFlags();
+	        	
+	    		Map<Hash, Long> state = new HashMap<>(Snapshot.latestSnapshot);
+	
+	            {
+	                int numberOfAnalyzedTransactions = 0;
+	
+	                final Queue<Long> nonAnalyzedTransactions = new LinkedList<>(Collections.singleton(StorageTransactions.instance().transactionPointer((extraTip == null ? preferableMilestone : extraTip).bytes())));
+	                Long pointer;
+	                while ((pointer = nonAnalyzedTransactions.poll()) != null) {
+	
+	                    if (StorageScratchpad.instance().setAnalyzedTransactionFlag(pointer)
+	                    		&& !Snapshot.confirmedSnapshotTransactions.contains(pointer)) // skip already confirmed transactions
+	                    {
+	
+	                        numberOfAnalyzedTransactions++;
+	
+	                        final Transaction transaction = StorageTransactions.instance().loadTransaction(pointer);
+	                        if (transaction.type == Storage.PREFILLED_SLOT) {
+	                            return null;
+	                        } else {
+	
+	                            if (transaction.currentIndex == 0) {
+	
+	                                boolean validBundle = false;
+	
+	                                final Bundle bundle = new Bundle(transaction.bundle);
+	                                for (final List<Transaction> bundleTransactions : bundle.getTransactions()) {
+	
+	                                    if (bundleTransactions.get(0).pointer == transaction.pointer) {
+	                                        validBundle = true;
+	                                        bundleTransactions.stream().filter(bundleTransaction -> bundleTransaction.value != 0).forEach(bundleTransaction -> {
+	                                        });
+	                                        break;
+	                                    }
+	                                }
+	
+	                                if (!validBundle) {
+	                                    return null;
+	                                }
+	                            }
+	                            if (transaction.value != 0) {
+		                            final Hash address = new Hash(transaction.address);
+		                            final Long value = state.get(address);
+		                            state.put(address, value == null ? transaction.value : (value + transaction.value));
+	                            }
+	                            nonAnalyzedTransactions.offer(transaction.trunkTransactionPointer);
+	                            nonAnalyzedTransactions.offer(transaction.branchTransactionPointer);
+	                        }
+	                    }
+	                }
+	
+	                log.info("Confirmed transactions = {}", numberOfAnalyzedTransactions);
+	            }
+	
+	            final Iterator<Map.Entry<Hash, Long>> stateIterator = state.entrySet().iterator();
+	            while (stateIterator.hasNext()) {
+	
+	                final Map.Entry<Hash, Long> entry = stateIterator.next();
+	                if (entry.getValue() <= 0) {
+	
+	                    if (entry.getValue() < 0) {
+	                    	log.error("Ledger inconsistency detected");
+	                        return null;
+	                    }
+	                    stateIterator.remove();
+	                }
+	            }
+	
+	            StorageScratchpad.instance().saveAnalyzedTransactionsFlags();
+	            StorageScratchpad.instance().clearAnalyzedTransactionsFlags();
+	
+	            final Set<Hash> tailsToAnalyze = new HashSet<>();
+	
+	            Hash tip = preferableMilestone;
+	            if (extraTip != null) {
+	
+	                Transaction transaction = StorageTransactions.instance().loadTransaction(StorageTransactions.instance().transactionPointer(tip.bytes()));
+	                while (depth-- > 0 && !tip.equals(Hash.NULL_HASH)) {
+	
+	                    tip = new Hash(transaction.hash, 0, Transaction.HASH_SIZE);
+	                    do {
+	                        transaction = StorageTransactions.instance().loadTransaction(transaction.trunkTransactionPointer);
+	                    } while (transaction.currentIndex != 0);
+	                }
+	            }
+	            final Queue<Long> nonAnalyzedTransactions = new LinkedList<>(Collections.singleton(StorageTransactions.instance().transactionPointer(tip.bytes())));
+	            Long pointer;
+	            while ((pointer = nonAnalyzedTransactions.poll()) != null) {
+	
+	                if (StorageScratchpad.instance().setAnalyzedTransactionFlag(pointer)) {
+	
+	                    final Transaction transaction = StorageTransactions.instance().loadTransaction(pointer);
+	
+	                    if (transaction.currentIndex == 0) {
+	                        tailsToAnalyze.add(new Hash(transaction.hash, 0, Transaction.HASH_SIZE));
+	                    }
+	
+	                    StorageApprovers.instance().approveeTransactions(StorageApprovers.instance().approveePointer(transaction.hash)).forEach(nonAnalyzedTransactions::offer);
+	                }
+	            }
+	
+	            if (extraTip != null) {
+	
+	                StorageScratchpad.instance().loadAnalyzedTransactionsFlags();
+	
+	                final Iterator<Hash> tailsToAnalyzeIterator = tailsToAnalyze.iterator();
+	                while (tailsToAnalyzeIterator.hasNext()) {
+	
+	                    final Transaction tail = StorageTransactions.instance().loadTransaction(tailsToAnalyzeIterator.next().bytes());
+	                    if (StorageScratchpad.instance().analyzedTransactionFlag(tail.pointer)) {
+	                        tailsToAnalyzeIterator.remove();
+	                    }
+	                }
+	            }
+	
+	            log.info(tailsToAnalyze.size() + " tails need to be analyzed");
+	            Hash bestTip = preferableMilestone;
+	            int bestRating = 0;
+	            for (final Hash tail : tailsToAnalyze) {
+	
+	            	StorageScratchpad.instance().loadAnalyzedTransactionsFlags();
+	
+	                Set<Hash> extraTransactions = new HashSet<>();
+	
+	                nonAnalyzedTransactions.clear();
+	                nonAnalyzedTransactions.offer(StorageTransactions.instance().transactionPointer(tail.bytes()));
+	                while ((pointer = nonAnalyzedTransactions.poll()) != null) {
+	
+	                    if (StorageScratchpad.instance().setAnalyzedTransactionFlag(pointer)
+	                    		&& !Snapshot.confirmedSnapshotTransactions.contains(pointer)) {
+	
+	                        final Transaction transaction = StorageTransactions.instance().loadTransaction(pointer);
+	                        
+	                        if (transaction.type == Storage.PREFILLED_SLOT) {
+	                            extraTransactions = null;
+	                            break;
+	                        } else {
+	                        	
+	                        	int weightMagnitude = 0;
+	                            int[] transactionTrits = new Hash(transaction.hash, 0, Transaction.HASH_SIZE).trits();
+	                            for (int pos = transactionTrits.length-1; pos>=0; pos-- ) {
+	                            	if (transactionTrits[pos] == 0) weightMagnitude++;
+	                            	else break;
+	                            }
+	                            
+	                            if (weightMagnitude < minWeightMagnitude) {
+	                            	extraTransactions = null;
+	                                break;
+	                            }
+	                        	
+	                            extraTransactions.add(new Hash(transaction.hash, 0, Transaction.HASH_SIZE));
+	                            nonAnalyzedTransactions.offer(transaction.trunkTransactionPointer);
+	                            nonAnalyzedTransactions.offer(transaction.branchTransactionPointer);
+	                        }
+	                    }
+	                }
+	
+	                if (extraTransactions != null) {
+	
+	                    Set<Hash> extraTransactionsCopy = new HashSet<>(extraTransactions);
+	
+	                    for (final Hash extraTransaction : extraTransactions) {
+	
+	                        final Transaction transaction = StorageTransactions.instance().loadTransaction(extraTransaction.bytes());
+	                        if (transaction != null && transaction.currentIndex == 0) {
+	
+	                            final Bundle bundle = new Bundle(transaction.bundle);
+	                            for (final List<Transaction> bundleTransactions : bundle.getTransactions()) {
+	
+	                                if (Arrays.equals(bundleTransactions.get(0).hash, transaction.hash)) {
+	
+	                                    for (final Transaction bundleTransaction : bundleTransactions) {
+	
+	                                        if (!extraTransactionsCopy.remove(new Hash(bundleTransaction.hash, 0, Transaction.HASH_SIZE))) {
+	                                            extraTransactionsCopy = null;
+	                                            break;
+	                                        }
+	                                    }
+	                                    break;
+	                                }
+	                            }
+	                        }
+	                        if (extraTransactionsCopy == null) {
+	                            break;
+	                        }
+	                    }
+	
+	                    if (extraTransactionsCopy != null && extraTransactionsCopy.isEmpty()) {
+	
+	                        final Map<Hash, Long> stateCopy = new HashMap<>(state);
+	
+	                        for (final Hash extraTransaction : extraTransactions) {
+	
+	                            final Transaction transaction = StorageTransactions.instance().loadTransaction(extraTransaction.bytes());
+	                            if (transaction.value != 0) {
+	                                final Hash address = new Hash(transaction.address);
+	                                final Long value = stateCopy.get(address);
+	                                stateCopy.put(address, value == null ? transaction.value : (value + transaction.value));
+	                            }
+	                        }
+	                        long total = 0l;
+	                        for (final long value : stateCopy.values()) {
+	                            if (value < 0) {
+	                                extraTransactions = null;
+	                                break;
+	                            }
+	                            total += value;
+	                        }
+	                        if (total != 2500000000000000l) {
+	                        	log.info("discarding tip. would cause invalid state.");
+	                        }
+	                        if (extraTransactions != null) {
+	                            if (extraTransactions.size() > bestRating) {
+	                                bestTip = tail;
+	                                bestRating = extraTransactions.size();
+	                            }
+	                        }
+	                    }
+	                }
+	            }
+	            log.info("{} extra transactions approved", bestRating);
+	            return bestTip;
+	        }
+    	}
+    	finally {
+    		Snapshot.updateSnapshotSemaphore.release();
+    	}
     }
     
     private static TipsManager instance = new TipsManager();


### PR DESCRIPTION
These features have been added
- Creation of a local snapshot
- Caching of confirmed transactions
- Added new API call (requestSnapshot) - can be called every 30 mins
- Major speedup for node restarts: Scans milestones from highest to lowest. Reduces node restarts and full solidity to minutes (provided local .store files are not corrupted)
- Major speedup for API calls getBalances, getTransactionToApprove, getInclusionStates by utilizing cached confirmed transactions and local snapshot